### PR TITLE
Todomvc tests - Ryan Collier

### DIFF
--- a/tests/todo-app.spec.ts
+++ b/tests/todo-app.spec.ts
@@ -116,3 +116,52 @@ test.describe('Delete Todo', () => {
     await checkNumberOfTodosInLocalStorage(page, 1);
   });
 });
+
+test.describe('Mark Todo as Completed', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('https://demo.playwright.dev/todomvc');
+  });
+
+  test('should be able to mark a todo item as completed', async ({ page }) => {
+    // Create a new todo locator
+    const newTodo = page.getByPlaceholder('What needs to be done?');
+
+    // Create the first todo item
+    await newTodo.fill(TODO_ITEMS[0]);
+    await newTodo.press('Enter');
+
+    // Verify the first todo item is created
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[0]]);
+
+    // Locate the checkbox to mark the todo as completed
+    const todoItem = page.getByTestId('todo-title').nth(0);
+    const toggleCheckbox = todoItem.locator('..').locator('.toggle');
+
+    // Click the checkbox to mark the todo as completed
+    await toggleCheckbox.click();
+
+    // Verify the todo item is marked as completed with a green checkmark
+    await expect(toggleCheckbox).toBeChecked();
+
+    // // Verify the todo item is crossed off with a strikethrough
+    // await expect(todoItem).toHaveClass(/completed/);
+
+    // Locate the parent <li> element of the todo item to verify the class
+    const todoListItem = todoItem.locator('..'); // Assuming the parent is <li>
+    const todoListItemParent = todoListItem.locator('..'); // Assuming the parent is <li>
+
+    // Verify the parent <li> element is marked as completed with the 'completed' class
+    await expect(todoListItemParent).toHaveClass(/completed/);
+
+    // Verify the todo item is crossed off with a strikethrough (usually happens automatically with the 'completed' class)
+    await expect(todoItem).toHaveCSS('text-decoration', /^line-through/);
+    // const textDecoration = await todoItem.evaluate((el) => window.getComputedStyle(el).textDecoration);
+    // expect(['line-through solid rgb(96, 96, 96)', 'line-through solid rgb(217, 217, 217)', 'line-through rgb(217, 217, 217)', 'line-through']).toContain(textDecoration);
+
+    // Verify the number of completed todos in local storage is 1
+    await checkNumberOfCompletedTodosInLocalStorage(page, 1);
+
+    // Verify the total number of todos in local storage is still 1
+    await checkNumberOfTodosInLocalStorage(page, 1);
+  });
+});

--- a/tests/todo-app.spec.ts
+++ b/tests/todo-app.spec.ts
@@ -7,7 +7,8 @@ test.beforeEach(async ({ page }) => {
 
 const TODO_ITEMS = [
   'complete code challenge',
-  'ensure coverage for all items is automated'
+  'ensure coverage for all items is automated',
+  'submit code challenge'
 ];
 
 test.describe('Create New Todo', () => {
@@ -33,7 +34,43 @@ test.describe('Create New Todo', () => {
       TODO_ITEMS[0],
       TODO_ITEMS[1]
     ]);
-
+    
+    // Make sure the list now has two todo items.
+    await expect(page.getByTestId('todo-title')).toHaveText([
+      TODO_ITEMS[0],
+      TODO_ITEMS[1],
+    ]);
     await checkNumberOfTodosInLocalStorage(page, 2);
+  });
+});
+
+test.describe('Edit Todo', () => {
+  test('should be able to edit a todo item', async ({ page }) => {
+
+    // Create a new todo locator
+    const newTodo = page.getByPlaceholder('What needs to be done?');
+
+    // Create 1st todo.
+    await newTodo.fill(TODO_ITEMS[0]);
+    await newTodo.press('Enter');
+
+    // Verify the first todo item is created
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[0]]);
+
+    // Double-click the first todo item to edit it
+    const todoItem = page.getByTestId('todo-title').nth(0);
+    await todoItem.dblclick();
+
+    // Edit the todo item and press Enter to save changes
+    const todoEditInput = page.locator('.editing .edit');
+    const UPDATED_TODO = 'updated code challenge';
+    await todoEditInput.fill(UPDATED_TODO);
+    await todoEditInput.press('Enter');
+
+    // Verify the todo item is updated with new changes
+    await expect(page.getByTestId('todo-title')).toHaveText([UPDATED_TODO]);
+
+    // Verify the number of todos in local storage is still 1
+    await checkNumberOfTodosInLocalStorage(page, 1);
   });
 });

--- a/tests/todo-app.spec.ts
+++ b/tests/todo-app.spec.ts
@@ -185,3 +185,54 @@ test.describe('View Active Todo Items', () => {
     await checkNumberOfTodosInLocalStorage(page, 2);
   });
 });
+
+test.describe('Clear Completed Todo Items', () => {
+  test('should clear completed todo items from the list and remove them from the local storage', async ({ page }) => {
+    // Create a new todo locator
+    const newTodo = page.getByPlaceholder('What needs to be done?');
+
+    // Create two todo items
+    await newTodo.fill(TODO_ITEMS[0]);
+    await newTodo.press('Enter');
+    await newTodo.fill(TODO_ITEMS[1]);
+    await newTodo.press('Enter');
+
+    // Verify both todo items are created
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[0], TODO_ITEMS[1]]);
+
+    // Mark the first todo item as completed
+    const firstTodoItem = page.getByTestId('todo-title').nth(0);
+    const toggleCheckbox = firstTodoItem.locator('..').locator('.toggle');
+    await toggleCheckbox.click();
+
+    // Correctly locate the parent <li> element of the todo item to verify the class
+    const firstTodoDiv = firstTodoItem.locator('..'); // This is the <div> with the class "view"
+    const firstTodoListItem = firstTodoDiv.locator('..'); // This is the parent <li> element
+
+    // Verify the parent <li> element is marked as completed with the 'completed' class
+    await expect(firstTodoListItem).toHaveClass(/completed/);
+
+    // Verify the number of completed todos in local storage is 1
+    await checkNumberOfCompletedTodosInLocalStorage(page, 1);
+
+    // Click on the "Clear completed" button to remove completed todos
+    await page.locator('text=Clear completed').click();
+
+    // // Verify the completed todo item is removed from the todo list
+    // await expect(firstTodoItem).toBeHidden();
+
+    // Verify that only the active todo item remains in the list
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[1]]);
+
+    // Verify the number of completed todos in local storage is now 0
+    await checkNumberOfCompletedTodosInLocalStorage(page, 0);
+
+    // Verify the total number of todos in local storage is now 1
+    await checkNumberOfTodosInLocalStorage(page, 1);
+  });
+
+  // The test case #6 spec suggests a todo item is moved to the Completed list when the "Clear Completed" 
+  // button is clicked. This action results in the item being removed from all lists, not moving to the
+  // completed list.
+
+});

--- a/tests/todo-app.spec.ts
+++ b/tests/todo-app.spec.ts
@@ -136,7 +136,7 @@ test.describe('Mark Todo as Completed', () => {
     await expect(toggleCheckbox).toBeChecked();
 
     // Locate the parent <li> element of the todo item to verify the class
-    const todoListItem = todoItem.locator('..'); // Assuming the parent is <li>
+    const todoListItem = todoItem.locator('..'); // This is not the parent <li>
     const todoListItemParent = todoListItem.locator('..'); // Assuming the parent is <li>
 
     // Verify the parent <li> element is marked as completed with the 'completed' class
@@ -150,5 +150,38 @@ test.describe('Mark Todo as Completed', () => {
 
     // Verify the total number of todos in local storage is still 1
     await checkNumberOfTodosInLocalStorage(page, 1);
+  });
+});
+
+test.describe('View Active Todo Items', () => {
+  test('should show only active (not completed) todo items in the Active list', async ({ page }) => {
+    // Create a new todo locator
+    const newTodo = page.getByPlaceholder('What needs to be done?');
+
+    // Create two todo items
+    await newTodo.fill(TODO_ITEMS[0]);
+    await newTodo.press('Enter');
+    await newTodo.fill(TODO_ITEMS[1]);
+    await newTodo.press('Enter');
+
+    // Verify both todo items are created
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[0], TODO_ITEMS[1]]);
+
+    // Mark the first todo item as completed
+    const firstTodoItem = page.getByTestId('todo-title').nth(0);
+    const toggleCheckbox = firstTodoItem.locator('..').locator('.toggle');
+    await toggleCheckbox.click();
+
+    // Verify the number of completed todos in local storage is 1
+    await checkNumberOfCompletedTodosInLocalStorage(page, 1);
+
+    // Click on the "Active" filter to view only active todos
+    await page.locator('text=Active').click();
+
+    // Verify only the second todo item (active) is visible
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[1]]);
+
+    // Verify the number of todos in local storage is still 2
+    await checkNumberOfTodosInLocalStorage(page, 2);
   });
 });

--- a/tests/todo-app.spec.ts
+++ b/tests/todo-app.spec.ts
@@ -77,10 +77,6 @@ test.describe('Edit Todo', () => {
 
 
 test.describe('Delete Todo', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('https://demo.playwright.dev/todomvc');
-  });
-
   test('should be able to delete a todo item using the red X button', async ({ page }) => {
     // Create a new todo locator
     const newTodo = page.getByPlaceholder('What needs to be done?');
@@ -118,10 +114,6 @@ test.describe('Delete Todo', () => {
 });
 
 test.describe('Mark Todo as Completed', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('https://demo.playwright.dev/todomvc');
-  });
-
   test('should be able to mark a todo item as completed', async ({ page }) => {
     // Create a new todo locator
     const newTodo = page.getByPlaceholder('What needs to be done?');
@@ -143,9 +135,6 @@ test.describe('Mark Todo as Completed', () => {
     // Verify the todo item is marked as completed with a green checkmark
     await expect(toggleCheckbox).toBeChecked();
 
-    // // Verify the todo item is crossed off with a strikethrough
-    // await expect(todoItem).toHaveClass(/completed/);
-
     // Locate the parent <li> element of the todo item to verify the class
     const todoListItem = todoItem.locator('..'); // Assuming the parent is <li>
     const todoListItemParent = todoListItem.locator('..'); // Assuming the parent is <li>
@@ -155,8 +144,6 @@ test.describe('Mark Todo as Completed', () => {
 
     // Verify the todo item is crossed off with a strikethrough (usually happens automatically with the 'completed' class)
     await expect(todoItem).toHaveCSS('text-decoration', /^line-through/);
-    // const textDecoration = await todoItem.evaluate((el) => window.getComputedStyle(el).textDecoration);
-    // expect(['line-through solid rgb(96, 96, 96)', 'line-through solid rgb(217, 217, 217)', 'line-through rgb(217, 217, 217)', 'line-through']).toContain(textDecoration);
 
     // Verify the number of completed todos in local storage is 1
     await checkNumberOfCompletedTodosInLocalStorage(page, 1);

--- a/tests/todo-app.spec.ts
+++ b/tests/todo-app.spec.ts
@@ -74,3 +74,45 @@ test.describe('Edit Todo', () => {
     await checkNumberOfTodosInLocalStorage(page, 1);
   });
 });
+
+
+test.describe('Delete Todo', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('https://demo.playwright.dev/todomvc');
+  });
+
+  test('should be able to delete a todo item using the red X button', async ({ page }) => {
+    // Create a new todo locator
+    const newTodo = page.getByPlaceholder('What needs to be done?');
+
+    // Create the first todo item
+    await newTodo.fill(TODO_ITEMS[0]);
+    await newTodo.press('Enter');
+
+    // Verify the first todo item is created
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[0]]);
+
+    // Create the second todo item
+    await newTodo.fill(TODO_ITEMS[1]);
+    await newTodo.press('Enter');
+
+    // Verify both todo items are created
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[0], TODO_ITEMS[1]]);
+
+    // Locate the delete button (red X) for the first todo item
+    const todoItem = page.getByTestId('todo-title').nth(0);
+    const deleteButton = todoItem.locator('..').locator('.destroy');
+
+    // Hover over the first todo item to reveal the delete button
+    await todoItem.hover();
+
+    // Click the delete button
+    await deleteButton.click();
+
+    // Verify the first todo item is removed
+    await expect(page.getByTestId('todo-title')).toHaveText([TODO_ITEMS[1]]);
+
+    // Verify the number of todos in local storage is now 1
+    await checkNumberOfTodosInLocalStorage(page, 1);
+  });
+});


### PR DESCRIPTION
Six Playwright test cases covering adding, editing, deleting, completing, and clearing of todoMVC list items.

They are run in parallel, however it could also be implemented in sequence if the first test case were to add three todo items, the following tests could each edit, delete, or complete the pre-existing items. This could cut down on run time and resources.